### PR TITLE
Update the name of the omm output script

### DIFF
--- a/coulttxml
+++ b/coulttxml
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Create code to add TT damping between Drude dipoles in OpenMM
-# Vinicius Piccoli, Agilio Padua <agilio.padua@ens-lyon.fr>, 2024/07/17
+# Mathieu Cancade, Vinicius Piccoli, Agilio Padua <agilio.padua@ens-lyon.fr>, 2025/03/05
 
 import sys
 import argparse
@@ -88,8 +88,6 @@ def count_molecules_from_pdbx(pdbx_filename):
 # -------------------------------------
 
 before = '''
-# OpenMM code to add charge-dipole damping in polarizable simulations
-
 # CoulTT damping function
 condition = "(don1*acc2 + don2*acc1) *"
 coulttexp = condition + "q1*q2/(fpe0*r)*(- c*exp(-b*r) * (1 + b*r + (b*r)^2/2 + (b*r)^3/6 + (b*r)^4/24))"
@@ -129,6 +127,8 @@ def main():
                         help = 'PDB file with configuration')
     parser.add_argument('--core', action = 'store_true',
                         help = 'Use core charge instead of induced dipole charge in TT damping')
+    parser.add_argument('--s', metavar = 'omm-p.py',
+                        help = 'OpenMM input script')
     args = parser.parse_args()
 
     print("force field from", args.xml)
@@ -138,6 +138,11 @@ def main():
     residues_xml = root.find('Residues').findall('Residue')
     residue_names_xml = [residue.attrib['name'] for residue in residues_xml]
 
+    atomtypes_xml = root.find('AtomTypes').findall('Type')
+    atomtypes_names_xml = [type.attrib['name'] for type in atomtypes_xml]    
+    atomtypes_masses_xml = [type.attrib['mass'] for type in atomtypes_xml]
+
+    light_atoms_mass_cutoff = 2.00
 
     if 'pdb' in args.pdb:
         num_molecules = count_molecules_from_pdb(args.pdb)
@@ -149,25 +154,79 @@ def main():
         print("Error: The number of different residues in the XML does not match the count from the PDB or PDBx file.")
         sys.exit(1)
 
-    with open('addCoulTT.py', 'w') as f:
-        f.write(before)
-        # Loop over each residue and its corresponding count from the PDB
-        f.write("# Put flag 1 in 1st or 2nd field in atoms to be screened\n")
-        f.write("# donor (1st field) is the charge, acceptor (2nd field) the induced dipole\n")
-        for residue_xml, count in zip(residue_names_xml, num_molecules):
-            f.write(f"for i in range({count}):\n")
-            atoms = next((res for res in residues_xml if res.attrib['name'] == residue_xml), None).findall('Atom')
-            for i, atom in enumerate(atoms):
-                name = atom.attrib['name']
-                charge = float(atom.attrib['charge'])
-                if not args.core and i < len(atoms) - 1:
-                    nxtname = atoms[i+1].attrib['name']
-                    if nxtname.startswith('D'):
-                        charge = - float(atoms[i+1].attrib['charge'])
-                f.write(f"    CoulTT.addParticle([0, 0, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
-        f.write(after)
+    if args.s is not None:
+        with open("omm-p-tt.py", 'w') as outputfile:
+            with open(args.s, 'r') as file:
+                data = file.readlines()
+                line = 0
+                while line < len(data):
+                    count = 0
+                    if data[line] == "### Forces ###\n":
+                        del data[line:line+1]
+                        outputfile.write("### Forces ###\n")
+                        outputfile.write("# Force settings before creating Simulation\n")
+                        
+                        outputfile.write(before)
+                        outputfile.write("# Tang-Toennis screening\n")
+                        outputfile.write("# Put flag 1 in 1st or 2nd field in atoms to be screened\n")
+                        outputfile.write("# donor (1st field) is the charge, acceptor (2nd field) the induced dipole\n")
+                        for residue_xml, count in zip(residue_names_xml, num_molecules):
+                            outputfile.write(f"for i in range({count}):\n")
+                            atoms = next((res for res in residues_xml if res.attrib['name'] == residue_xml), None).findall('Atom')
+                            for i, atom in enumerate(atoms):
+                                name = atom.attrib['name']
+                                charge = float(atom.attrib['charge'])
+                                if not args.core and i < len(atoms) - 1:
+                                    nxtname = atoms[i+1].attrib['name']
+                                    if nxtname.startswith('D'):
+                                        charge = - float(atoms[i+1].attrib['charge'])
+                                for k in range(0, len(atomtypes_xml)):
+                                    if atom.attrib['type'] == atomtypes_names_xml[k]:
+                                        if atomtypes_xml[k].attrib["class"] == "DRUD":
+                                            outputfile.write(f"    CoulTT.addParticle([0, 1, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
+                                        elif float(atomtypes_xml[k].attrib["mass"]) < light_atoms_mass_cutoff:
+                                            outputfile.write(f"    CoulTT.addParticle([0, 0, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
+                                        elif float(atomtypes_xml[k].attrib["mass"]) > light_atoms_mass_cutoff:
+                                            outputfile.write(f"    CoulTT.addParticle([0, 1, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
+                        
+                        outputfile.write(after)
+                        count = count+1
+                    
+                    elif count == 0:
+                        outputfile.write(data[line])
+                    
+                    line = line +1
+        
+        print("Tang-Toennis parameters written to omm-p-tt.py")
 
-    print("OpenMM code for CoulTT written to addCoulTT.py")
+    elif args.s is None:
+        with open('addCoulTT.py', 'w') as f:
+            f.write("# OpenMM code to add charge-dipole damping in polarizable simulations\n")
+            f.write(before)
+            # Loop over each residue and its corresponding count from the PDB
+            f.write("# Put flag 1 in 1st or 2nd field in atoms to be screened\n")
+            f.write("# donor (1st field) is the charge, acceptor (2nd field) the induced dipole\n")
+            for residue_xml, count in zip(residue_names_xml, num_molecules):
+                f.write(f"for i in range({count}):\n")
+                atoms = next((res for res in residues_xml if res.attrib['name'] == residue_xml), None).findall('Atom')
+                for i, atom in enumerate(atoms):
+                    name = atom.attrib['name']
+                    charge = float(atom.attrib['charge'])
+                    if not args.core and i < len(atoms) - 1:
+                        nxtname = atoms[i+1].attrib['name']
+                        if nxtname.startswith('D'):
+                            charge = - float(atoms[i+1].attrib['charge'])
+                    for k in range(0, len(atomtypes_xml)):
+                        if atom.attrib['type'] == atomtypes_names_xml[k]:
+                            if atomtypes_xml[k].attrib["class"] == "DRUD":
+                                f.write(f"    CoulTT.addParticle([0, 1, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
+                            elif float(atomtypes_xml[k].attrib["mass"]) < light_atoms_mass_cutoff:
+                                f.write(f"    CoulTT.addParticle([0, 0, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
+                            elif float(atomtypes_xml[k].attrib["mass"]) > light_atoms_mass_cutoff:
+                                f.write(f"    CoulTT.addParticle([0, 1, {charge:8.5f}]) # {name:4s} {atom.attrib['type']:12s}\n")
+            f.write(after)
+
+        print("OpenMM code for CoulTT written to addCoulTT.py")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
For notation consistency, an "omm-p-tt.py" file is written instead of an "omm-p-sc.py" one. It prevent confusions with the "field-p-sc.py" file name, in which the "-sc" refers to the scaling of LJ parameters.